### PR TITLE
fix import error in krboversmb.py

### DIFF
--- a/krbjack/modules/krboversmb.py
+++ b/krbjack/modules/krboversmb.py
@@ -2,7 +2,7 @@ from scapy.layers.smb2 import SMB2_Header, SMB2_Session_Setup_Request
 from krbjack.modules.utils import HomeBackedPSEXEC
 from impacket.smbconnection import SessionError
 from scapy.layers.kerberos import KRB_AP_REQ
-from scapy.layers.gssapi import SPNEGO_Token
+from scapy.layers.spnego import SPNEGO_Token
 
 from .utils import getAuthenticatedImpacketSMBConnection
 


### PR DESCRIPTION
Currently `krbjack` crashes with the import error shown below. This PR fixes that.

~~~
❯ krbjack check --domain redacted.local --dc-ip 192.168.X.Y

        ██╗  ██╗██████╗ ██████╗      ██╗ █████╗  ██████╗██╗  ██╗
        ██║ ██╔╝██╔══██╗██╔══██╗     ██║██╔══██╗██╔════╝██║ ██╔╝
        █████╔╝ ██████╔╝██████╔╝     ██║███████║██║     █████╔╝
        ██╔═██╗ ██╔══██╗██╔══██╗██   ██║██╔══██║██║     ██╔═██╗
        ██║  ██╗██║  ██║██████╔╝╚█████╔╝██║  ██║╚██████╗██║  ██╗
        ╚═╝  ╚═╝╚═╝  ╚═╝╚═════╝  ╚════╝ ╚═╝  ╚═╝ ╚═════╝╚═╝  ╚═╝
        A full duplex man-in-the-middle tool to abuse unsecure updates DNS
        configuration on active directory and Kerberos AP_REQ hijacking.
        Please read the README/wiki to understand what you are doing here,
        a DoS is easy to do from there...
        - @almandin

Traceback (most recent call last):
  File "/redacted/krbjack/.venv/bin/krbjack", line 8, in <module>
    sys.exit(main())
             ~~~~^^
  File "/redacted/krbjack/krbjack/__main__.py", line 102, in main
    jacker = KrbJacker(args, modules)
  File "/redacted/krbjack/krbjack/krbjacker.py", line 25, in __init__
    self.available_modules = [importlib.import_module(f"krbjack.modules.{m}") for m in modules]
                              ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/importlib/__init__.py", line 88, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 1026, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/redacted/krbjack/krbjack/modules/krboversmb.py", line 5, in <module>
    from scapy.layers.gssapi import SPNEGO_Token
ImportError: cannot import name 'SPNEGO_Token' from 'scapy.layers.gssapi' (/redacted/krbjack/.venv/lib/python3.13/site-packages/scapy/layers/gssapi.py)
~~~